### PR TITLE
Fixes vpc_subnet_count to get value from subnets dependency

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -38,7 +38,7 @@ versions:
     - name: vpc_subnet_count
       moduleRef:
         id: vpc
-        output: count
+        output: subnets
     - name: vpc_subnets
       moduleRef:
         id: subnets


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>