### PR TITLE
Updates handling of kube config

### DIFF
--- a/main-2-config.tf
+++ b/main-2-config.tf
@@ -68,14 +68,6 @@ resource null_resource setup_kube_config {
   depends_on = [null_resource.create_dirs, data.ibm_container_cluster_config.cluster]
 
   provisioner "local-exec" {
-    command = "rm -f ${local.cluster_config} && ln -s ${data.ibm_container_cluster_config.cluster.config_file_path} ${local.cluster_config}"
-  }
-
-  provisioner "local-exec" {
-    command = "cp ${regex("(.*)/config.yml", data.ibm_container_cluster_config.cluster.config_file_path)[0]}/* ${local.cluster_config_dir}"
-  }
-
-  provisioner "local-exec" {
     command = "echo 'Waiting for 5 minutes for permissions to be established...' && sleep 300"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
     }
   }
   cluster_config_dir    = "${path.cwd}/.kube"
-  cluster_config        = "${local.cluster_config_dir}/config"
+  cluster_config        = data.ibm_container_cluster_config.cluster.config_file_path
   cluster_type_file     = "${path.cwd}/.tmp/cluster_type.val"
   name_prefix           = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
   name_list             = [local.name_prefix, "cluster"]
@@ -48,9 +48,14 @@ locals {
 }
 
 resource null_resource create_dirs {
+  triggers = {
+    always_run = timestamp()
+  }
+
   provisioner "local-exec" {
     command = "echo 'regex: ${local.cluster_regex}'"
   }
+
   provisioner "local-exec" {
     command = "echo 'cluster_type_cleaned: ${local.cluster_type_cleaned}'"
   }
@@ -76,6 +81,7 @@ resource null_resource print_resources {
   }
 }
 
+# separated to prevent circular dependency
 resource null_resource print_subnets {
   provisioner "local-exec" {
     command = "echo 'VPC subnet count: ${local.vpc_subnet_count}'"


### PR DESCRIPTION
- Always run the create_dirs resource
- Don't move the kubeconfig files, refer to them where they are created

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>