### PR TITLE
Removes kms_id from test if kms encryption should be enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ locals {
   vpc_subnets           = !var.exists ? var.vpc_subnets : []
   security_group_id     = !var.exists ? data.ibm_is_vpc.vpc[0].default_security_group : ""
   ipv4_cidr_blocks      = !var.exists ? data.ibm_is_subnet.vpc_subnet[*].ipv4_cidr_block : []
-  kms_enabled           = var.kms_id != "" && var.kms_key_id != ""
+  kms_enabled           = var.kms_key_id != ""
   kms_config            = local.kms_enabled ? [{
     instance_id      = var.kms_id
     crk_id           = var.kms_key_id


### PR DESCRIPTION
- kms_id will usually be looked up and will not be available at the time of `terraform plan` to determine the value

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>