### PR TITLE
Updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ resource ibm_container_vpc_worker_pool cluster_pool {
   count             = !var.exists ? local.vpc_subnet_count - 1 : 0
 
   cluster           = ibm_container_vpc_cluster.cluster[0].id
-  worker_pool_name  = "${local.cluster_name}-wp-${format("%02s", count.index + 1)}"
+  worker_pool_name  = "pool-${format("%02s", count.index + 2)}"
   flavor            = var.flavor
   vpc_id            = local.vpc_id
   worker_count      = var.worker_count

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,8 @@ locals {
     "kms",
     "hs-crypto"
   ]
-  cluster_config        = var.login ? data.ibm_container_cluster_config.cluster[0].config_file_path : ""
+  login                 = var.login ? var.login : !var.disable_public_endpoint
+  cluster_config        = local.login ? data.ibm_container_cluster_config.cluster[0].config_file_path : ""
 }
 
 resource null_resource create_dirs {
@@ -204,7 +205,7 @@ resource "null_resource" "list_tmp" {
 
 
 data ibm_container_cluster_config cluster_admin {
-  count = var.login ? 1 : 0
+  count = local.login ? 1 : 0
   depends_on        = [data.ibm_container_vpc_cluster.config, null_resource.list_tmp]
 
   cluster_name_id   = local.cluster_name
@@ -214,7 +215,7 @@ data ibm_container_cluster_config cluster_admin {
 }
 
 data ibm_container_cluster_config cluster {
-  count = var.login ? 1 : 0
+  count = local.login ? 1 : 0
   depends_on        = [
     data.ibm_container_vpc_cluster.config,
     null_resource.list_tmp,
@@ -227,7 +228,7 @@ data ibm_container_cluster_config cluster {
 }
 
 resource null_resource setup_kube_config {
-  count = var.login ? 1 : 0
+  count = local.login ? 1 : 0
   depends_on = [null_resource.create_dirs, data.ibm_container_cluster_config.cluster]
 
   provisioner "local-exec" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,7 @@ output "platform" {
     ingress    = local.ingress_hostname
     tls_secret = local.tls_secret
   }
+  sensitive = true
   description = "Configuration values for the cluster platform"
   depends_on  = [data.ibm_container_vpc_cluster.config]
 }

--- a/scripts/open-acl-rules.sh
+++ b/scripts/open-acl-rules.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+NETWORK_ACL="$1"
+
+## TODO more sophisiticated logic needed to 1) test for existing rules and 2) place this rule in the right order
+
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow inbound all "0.0.0.0/0" "0.0.0.0/0" --name allow-all-ingress
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow outbound all "0.0.0.0/0" "0.0.0.0/0" --name allow-all-egress

--- a/test/stages/stage1-subnets.tf
+++ b/test/stages/stage1-subnets.tf
@@ -5,7 +5,6 @@ module "subnets" {
   region            = var.region
   ibmcloud_api_key  = var.ibmcloud_api_key
   vpc_name          = module.vpc.name
-  acl_id            = module.vpc.acl_id
   gateways          = module.gateways.gateways
   _count            = 2
   label             = "bastion"


### PR DESCRIPTION
- Adds rules for subnet acl and security group (#35)
    - Allows inbound and outbound acl traffic to the internet
    - Allows inbound ping, http, and https traffic
- Sets login flag if public endpoints are enabled (#33)
- Simplifies name of worker pool (#32)
- Update output platform to a sensitive value (#29)

