### PR TITLE
fix local.cluster_version so it doesn't crash on destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ locals {
   # value should be ocp4, ocp3, or kubernetes
   cluster_type_code     = local.config_values[local.cluster_type_cleaned].type_code
   cluster_type_tag      = local.cluster_type == "kubernetes" ? "iks" : "ocp"
-  cluster_version       = local.cluster_type == "openshift" ? local.openshift_versions[local.config_values[local.cluster_type_cleaned].version] : ""
+  cluster_version       = local.cluster_type == "openshift" ? "${var.ocp_version}_openshift" : ""
   vpc_subnet_count      = var.vpc_subnet_count
   vpc_id                = !var.exists ? data.ibm_is_vpc.vpc[0].id : ""
   vpc_subnets           = !var.exists ? var.vpc_subnets : []


### PR DESCRIPTION
When running `terraform destroy` on a cluster provisioned with this code, it would crash the IBM Cloud plugin with
```
╷
│ Error: Plugin did not respond
│
│   with module.cluster.ibm_container_vpc_cluster.cluster[0],
│   on cluster/main.tf line 201, in resource "ibm_container_vpc_cluster" "cluster":
│  201: resource ibm_container_vpc_cluster cluster {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).PlanResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-ibm_v1.34.0 plugin:

panic: runtime error: index out of range [1] with length 1

goroutine 297 [running]:
github.com/IBM-Cloud/terraform-provider-ibm/ibm.resourceIBMContainerVpcCluster.func2(0x36d3fb8, 0xc, 0xc000650d30, 0x10, 0x3726574, 0x24, 0xc000494700, 0x203000)
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/resource_ibm_container_vpc_cluster.go:133 +0x3d2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.diff(0xc000d46cc0, 0x36d3fb8, 0xc, 0xc000d7ca00, 0xc000f20da0, 0x3c04ce0, 0xc000494700, 0xc00102f600, 0x314b900, 0xc00102f670)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/schema.go:972 +0x383
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0xc000d46cc0, 0x3bf80a8, 0xc0002a3880, 0xc0001993b0, 0xc0011477d0, 0xc0000af780, 0x36b3a00, 0xc001036000, 0x4a98600, 0x314b900, ...)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/schema.go:522 +0x219
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0xc000d7e380, 0x3bf80a8, 0xc0002a3880, 0xc0001993b0, 0xc0011477d0, 0x36b3a00, 0xc001036000, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:506 +0xa5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0xc00079a0c0, 0x3bf80a8, 0xc0002a3880, 0xc001513810, 0xc0002a3880, 0x35d6780, 0xc0016b5600)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:693 +0x7c5
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).PlanResourceChange(0xc00063b880, 0x3bf8150, 0xc0002a3880, 0xc0001992d0, 0xc00063b880, 0xc0016b5650, 0xc000eb3ba0)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:315 +0xb5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_PlanResourceChange_Handler(0x35d6780, 0xc00063b880, 0x3bf8150, 0xc0016b5650, 0xc0010ba600, 0x0, 0x3bf8150, 0xc0016b5650, 0xc0005cb900, 0x1060)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:362 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc001612000, 0x3c11898, 0xc0004d9c80, 0xc0015aa400, 0xc00061e7b0, 0x4a37e08, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc001612000, 0x3c11898, 0xc0004d9c80, 0xc0015aa400, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00049ee00, 0xc001612000, 0x3c11898, 0xc0004d9c80, 0xc0015aa400)
	google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-ibm_v1.34.0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

This update fixes this issue