### PR TITLE
Vary name_prefix in tests to fix ci collision

### DIFF
--- a/test/stages/stage0.tf
+++ b/test/stages/stage0.tf
@@ -5,5 +5,19 @@ terraform {
     ibm = {
       source = "ibm-cloud/ibm"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.1.0"
+    }
   }
+}
+
+locals {
+  name_prefix_test = "${var.name_prefix}-${random_string.this.result}"
+}
+
+resource "random_string" "this" {
+  length = 6
+  special = false
+  upper = false
 }

--- a/test/stages/stage1-cos.tf
+++ b/test/stages/stage1-cos.tf
@@ -3,5 +3,5 @@ module "cos" {
 
   provision = true
   resource_group_name = module.resource_group.name
-  name_prefix = var.name_prefix
+  name_prefix = local.name_prefix_test
 }

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -3,5 +3,5 @@ module "vpc" {
 
   resource_group_name = module.resource_group.name
   region              = var.region
-  name_prefix         = var.name_prefix
+  name_prefix         = local.name_prefix_test
 }

--- a/test/stages/stage2-cluster.tf
+++ b/test/stages/stage2-cluster.tf
@@ -8,7 +8,7 @@ module "cluster" {
   worker_count        = var.worker_count
   ocp_version         = var.ocp_version
   exists              = var.cluster_exists
-  name_prefix         = var.name_prefix
+  name_prefix         = local.name_prefix_test
   vpc_name            = module.subnets.vpc_name
   vpc_subnets         = module.subnets.subnets
   vpc_subnet_count    = module.subnets.count


### PR DESCRIPTION
Create a local in the test code so that name collisions with existing cluster or vpc are avoided when there are concurrent CI runs happening in multiple modules.

Signed-off-by: Tim Robinson <timroster@gmail.com>